### PR TITLE
Add support for parsing of time.Time using Result.Time()

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -13,7 +13,11 @@ func parseStructureType(result gjson.Result, field reflect.Type) (v interface{})
 	case reflect.Map:
 		v = unmarshalMap(result.Raw, field)
 	case reflect.Struct:
-		v = unmarshalStruct(result.Raw, field)
+		if field.String() == "time.Time" {
+			v = result.Time()
+		} else {
+			v = unmarshalStruct(result.Raw, field)
+		}
 	default:
 		v = nil
 	}


### PR DESCRIPTION
Found a solution to #2. 