### PR TITLE
Unmarshal: support non-nested json tags

### DIFF
--- a/etc.go
+++ b/etc.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func validTag(filed reflect.StructField) bool {
+func validTag(filed reflect.StructField, tag string) bool {
 	return !(filed.Tag.Get(tag) == "" ||
 		filed.Tag.Get(tag) == "-")
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -260,7 +260,7 @@ func TestUnmarshalSlices(t *testing.T) {
 			[
 				[
 					601, 602, 603
-				],
+				]
 			]
 
 		],
@@ -429,7 +429,7 @@ func TestUnmarshalComplex(t *testing.T) {
 		],
 		"time_1": "2021-01-11T23:56:51.141Z",
 		"time_2": "2021-01-11T23:56:51.141+01:00",
-		"time_3": "2021-01-11T23:56:51.141-01:00",
+		"time_3": "2021-01-11T23:56:51.141-01:00"
 	  }
 	`
 
@@ -549,4 +549,94 @@ func TestUnmarshalMoreComplex(t *testing.T) {
 		t.Error(diff)
 	}
 
+}
+
+func TestUnmarshalJson(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		json := `
+		{
+			"name": {"first": "Mohamed", "last": "Shapan"},
+			"age": 26,
+			"friends": [
+				{"first": "Asma", "age": 26},
+				{"first": "Ahmed", "age": 25},
+				{"first": "Mahmoud", "age": 30}
+			]
+		}`
+
+		type Name struct {
+			First string `njson:"first"`
+			Last  string `njson:"last"`
+		}
+
+		type User struct {
+			Name    Name   `njson:"name"`
+			Age     int    `json:"age"`
+			Friends []Name `json:"friends"`
+		}
+
+		actual := User{}
+
+		err := Unmarshal([]byte(json), &actual)
+		if err != nil {
+			t.Error(err)
+		}
+
+		var friends []Name
+		friends = append(friends, Name{
+			First: "Asma",
+		})
+
+		friends = append(friends, Name{
+			First: "Ahmed",
+		})
+
+		friends = append(friends, Name{
+			First: "Mahmoud",
+		})
+
+		expected := User{
+			Name: Name{
+				First: "Mohamed",
+				Last:  "Shapan",
+			},
+			Age:     26,
+			Friends: friends,
+		}
+
+		diff := cmp.Diff(expected, actual)
+		if diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		json := `
+		{
+			"name": {"first": "Mohamed", "last": "Shapan"},
+			"age": 26,
+			"friends": [
+				{"first": "Asma", "age": 26},
+				{"first": "Ahmed", "age": 25},
+				{"first": "Mahmoud", "age": 30}
+			]
+		}`
+
+		type Name struct {
+			First string `njson:"first"`
+			Last  string `njson:"last"`
+		}
+
+		type User struct {
+			Name    string `json:"name.first"`
+			Age     int    `json:"age"`
+			Friends []Name `json:"friends"`
+		}
+
+		actual := User{}
+
+		if err := Unmarshal([]byte(json), &actual); err == nil {
+			t.Error("error should not be nil")
+		}
+	})
 }


### PR DESCRIPTION
This pull request adds support for structs with "json" tags, as well as structs with "json" and "njson" tags.

If the tag is "json", it will be only be considered valid if the tag is not nested—nested tags will be required to use the "njson" tag.

Resolves #7